### PR TITLE
Force generation to use strategy defined within the factories meta

### DIFF
--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -210,7 +210,7 @@ def model_fixture(request, factory_name):
         if argname in request._fixturedef.argnames:
             kwargs[key] = evaluate(request, request.getfixturevalue(argname))
 
-    strategy = factory.enums.CREATE_STRATEGY
+    strategy = Factory._meta.strategy
     builder = factory.builder.StepBuilder(Factory._meta, kwargs, strategy)
     step = factory.builder.BuildStep(builder=builder, sequence=Factory._meta.next_sequence())
 

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -1,6 +1,7 @@
 """pytest-factoryboy plugin."""
 
 from collections import defaultdict
+from factory import enums
 import pytest
 
 
@@ -72,6 +73,7 @@ class Request(object):
             results = self.results.pop(model)
             obj = request.getfixturevalue(model)
             factory = self.model_factories[model]
+            create = factory._meta.strategy == enums.CREATE_STRATEGY
             factory._after_postgeneration(obj, create=True, results=results)
 
     def evaluate(self, request):


### PR DESCRIPTION
- Default in case non-set is CREATE_STRATEGY. So this conforms to the absolute hardcoded default from before.
